### PR TITLE
speeding up build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,9 +3,9 @@ name: Check Set-Up & Build
 # Controls when the action will run.
 on:
   push:
-    branches: "*"
+    branches: '*'
   pull_request:
-    branches: "*"
+    branches: '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,7 +18,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-        
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,7 +31,7 @@ jobs:
           source ~/.cargo/env
           rustup default stable
           rustup update stable
-      
+
       - name: Check Formatting
         run: >
           cargo fmt --check
@@ -42,4 +41,4 @@ jobs:
 
       - name: Test Build
         run: >
-          cargo test -- --test-threads 1 
+          cargo test --workspace -- --test-threads 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set-Up
-        #run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source ~/.cargo/env

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,21 +23,28 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set-Up
-        run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
-
-      - name: Install Rustup
+        #run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source ~/.cargo/env
+
+      - name: ⚡ Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Set Rustup Channel
+        run: |
           rustup default stable
           rustup update stable
 
       - name: Check Formatting
         run: >
           cargo fmt --check
-
-      - name: Enable caching
-        uses: Swatinem/rust-cache@v1.3.0
 
       - name: Test Build
         run: >

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Test Build
         run: >
-          cargo test --workspace -- --test-threads 1
+          cargo test --workspace --lib -- --test-threads 1

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm -rf Private.key Public.key identity.db message.db test.txt
-cargo test -- --test-threads 1
+cargo test --workspace -- --test-threads 1

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm -rf Private.key Public.key identity.db message.db test.txt
-cargo test --workspace -- --test-threads 1
+cargo test --workspace --lib -- --test-threads 1


### PR DESCRIPTION
- fix: with the addition of a workspace member, the `--workspace` option is needed when running `cargo test ...` in order to include the tests of workspaces members
- improvement: dramatically increased the speed of the build with proper caching of rust artifacts: down to ~4 min from 15-19 min